### PR TITLE
Change Travis builds to Django 1.11 and 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,21 @@
 language: python
 env:
-  - DJANGO_VERSION=1.8 DRF_VERSION=2.4
-  - DJANGO_VERSION=1.9 DRF_VERSION=2.4
-  - DJANGO_VERSION=1.10 DRF_VERSION=2.4
-  - DJANGO_VERSION=1.8 DRF_VERSION=3.6
-  - DJANGO_VERSION=1.9 DRF_VERSION=3.6
-  - DJANGO_VERSION=1.10 DRF_VERSION=3.6
+  - DJANGO_VERSION=1.11 DRF_VERSION=2.4
+  - DJANGO_VERSION=2.0 DRF_VERSION=2.4
+  - DJANGO_VERSION=1.11 DRF_VERSION=3.7
+  - DJANGO_VERSION=2.0 DRF_VERSION=3.7
 python:
   - "2.7"
   - "3.6"
+matrix:
+  exclude:
+    - env: DJANGO_VERSION=2.0 DRF_VERSION=2.4
+      python: "2.7"
+    - env: DJANGO_VERSION=2.0 DRF_VERSION=3.7
+      python: "2.7"
 install:
   - pip install -q Django==$DJANGO_VERSION
-  - pip install -q djangorestframework==$DRF_VERSION
+  - pip install -q djangorestframework>=$DRF_VERSION
   - python setup.py -q install
   - pip install -r requirements-test.txt
 script: ./runtests

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
 Django>=1.10
 djangorestframework>=3.3
-coverage==4.4.1
+coverage==4.5.1
 flake8==3.5.0


### PR DESCRIPTION
New Django versions have been released; this PR updates the builds:

- Remove builds for Django 1.8, 1.9, 1.11
- Add builds for Django 1.11, 2.0
- Update coverage (Resolves #7)