### PR TITLE
Ensure IRIs are supported during token generation and authentication.

### DIFF
--- a/rest_framework_tmp_scoped_token/__init__.py
+++ b/rest_framework_tmp_scoped_token/__init__.py
@@ -2,7 +2,7 @@
 from .auth import TokenAuth
 from .token import TokenManager
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'
 __license__ = 'GNU Affero General Public License v3.0'
 __description__ = 'Temporary Django REST Framework permission-scoped token'
 __author__ = 'Anthony Lukach'


### PR DESCRIPTION
It's important that our temporary scoped tokens support both IRIs (`/tést`) and URIs (`/t%C3%A9st`) when generating the token and when authenticating the token. Basically, a token for `/tést` should be able to authenticate a request to a URL like `/tést/foo` or `/t%C3%A9s/foo` and a token for `/t%C3%A9s` should be able authenticate a URL like `/t%C3%A9s/foo` or `/tést/foo`.

Luckily, Django offers [`django.utils.encoding.iri_to_uri()`](https://docs.djangoproject.com/en/2.0/ref/utils/#django.utils.encoding.iri_to_uri) to make this easy.